### PR TITLE
fix(bgs): Dots

### DIFF
--- a/packages/bgs/src/createBackgroundDots/createBackgroundDots.ts
+++ b/packages/bgs/src/createBackgroundDots/createBackgroundDots.ts
@@ -104,7 +104,8 @@ const createBackgroundDots = (props: CreateBackgroundDotsProps): CreateBackgroun
 
     const { color, type, distance, size, crossSize, origin, originInverted } = getSettings()
 
-    const { width, height } = canvas
+    const width = canvas.clientWidth
+    const height = canvas.clientHeight
 
     const xLength = 1 + Math.floor(width / distance)
     const yLength = 1 + Math.floor(height / distance)
@@ -112,6 +113,8 @@ const createBackgroundDots = (props: CreateBackgroundDotsProps): CreateBackgroun
     const xMargin = width % distance
     const yMargin = height % distance
 
+    canvas.width = width
+    canvas.height = height
     ctx.clearRect(0, 0, width, height)
 
     for (let xIndex = 0; xIndex < xLength; xIndex++) {


### PR DESCRIPTION
Fix the Dots bg's canvas size calculation to match with other types of bgs. Otherwise the Dots bg would not align with other bgs such as GridLines, there will be horizontal and vertical offsets caused by wrong calculations of canvas sizes.

Please make sure you have reviewed the [contribution guidelines](./CONTRIBUTING.md)
for this project.

- [x] Make sure you are making a pull request against the **next** branch
(left side). Also you should start *your branch* off it.
- [x] Check the commit's or even all commits' message styles matches our requested
structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Description

The previous implementation of Dots bg's canvas calculation is different from other types of bgs, leading to vertical and horizontal offsets when using them at the same time. Fixing the Dots bg's calculation to match the others.
