### PR TITLE
Release v1.0.0-next.24072501

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,9 +1,9 @@
 {
   "name": "apps-docs",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "private": true,
   "dependencies": {
-    "@arwes/react": "^1.0.0-next.24072301",
+    "@arwes/react": "^1.0.0-next.24072501",
     "autoprefixer": "^10.4.19",
     "iconoir-react": "^7.7.0",
     "jotai": "^2.9.0",

--- a/apps/perf/package.json
+++ b/apps/perf/package.json
@@ -1,10 +1,10 @@
 {
   "name": "apps-perf",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "private": true,
   "dependencies": {
-    "@arwes/react": "^1.0.0-next.24072301",
-    "arwes": "^1.0.0-next.24072301",
+    "@arwes/react": "^1.0.0-next.24072501",
+    "arwes": "^1.0.0-next.24072501",
     "copy-webpack-plugin": "^12.0.2",
     "html-webpack-plugin": "^5.6.0",
     "ts-loader": "^9.5.1",

--- a/apps/play/package.json
+++ b/apps/play/package.json
@@ -1,12 +1,12 @@
 {
   "name": "apps-play",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "private": true,
   "dependencies": {
-    "@arwes/react": "^1.0.0-next.24072301",
+    "@arwes/react": "^1.0.0-next.24072501",
     "@babel/core": "^7.24.9",
     "@babel/preset-react": "^7.24.7",
-    "arwes": "^1.0.0-next.24072301",
+    "arwes": "^1.0.0-next.24072501",
     "babel-loader": "^9.1.3",
     "copy-webpack-plugin": "^12.0.2",
     "empanada": "^0.2.4",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "command": {
     "publish": {
       "allowBranch": "dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,9 +45,9 @@
     },
     "apps/docs": {
       "name": "apps-docs",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "dependencies": {
-        "@arwes/react": "^1.0.0-next.24072301",
+        "@arwes/react": "^1.0.0-next.24072501",
         "autoprefixer": "^10.4.19",
         "iconoir-react": "^7.7.0",
         "jotai": "^2.9.0",
@@ -59,10 +59,10 @@
     },
     "apps/perf": {
       "name": "apps-perf",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "dependencies": {
-        "@arwes/react": "^1.0.0-next.24072301",
-        "arwes": "^1.0.0-next.24072301",
+        "@arwes/react": "^1.0.0-next.24072501",
+        "arwes": "^1.0.0-next.24072501",
         "copy-webpack-plugin": "^12.0.2",
         "html-webpack-plugin": "^5.6.0",
         "ts-loader": "^9.5.1",
@@ -74,12 +74,12 @@
     },
     "apps/play": {
       "name": "apps-play",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "dependencies": {
-        "@arwes/react": "^1.0.0-next.24072301",
+        "@arwes/react": "^1.0.0-next.24072501",
         "@babel/core": "^7.24.9",
         "@babel/preset-react": "^7.24.7",
-        "arwes": "^1.0.0-next.24072301",
+        "arwes": "^1.0.0-next.24072501",
         "babel-loader": "^9.1.3",
         "copy-webpack-plugin": "^12.0.2",
         "empanada": "^0.2.4",
@@ -19985,7 +19985,7 @@
     },
     "packages/animated": {
       "name": "@arwes/animated",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
         "tslib": "2"
@@ -19996,10 +19996,10 @@
     },
     "packages/animator": {
       "name": "@arwes/animator",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20008,11 +20008,11 @@
     },
     "packages/bgs": {
       "name": "@arwes/bgs",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animated": "^1.0.0-next.24072301",
-        "@arwes/animator": "^1.0.0-next.24072301",
+        "@arwes/animated": "^1.0.0-next.24072501",
+        "@arwes/animator": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20024,7 +20024,7 @@
     },
     "packages/bleeps": {
       "name": "@arwes/bleeps",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
         "tslib": "2"
@@ -20035,10 +20035,10 @@
     },
     "packages/frames": {
       "name": "@arwes/frames",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "csstype": "3",
         "tslib": "2"
       },
@@ -20048,18 +20048,18 @@
     },
     "packages/react": {
       "name": "@arwes/react",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/react-animated": "^1.0.0-next.24072301",
-        "@arwes/react-animator": "^1.0.0-next.24072301",
-        "@arwes/react-bgs": "^1.0.0-next.24072301",
-        "@arwes/react-bleeps": "^1.0.0-next.24072301",
-        "@arwes/react-core": "^1.0.0-next.24072301",
-        "@arwes/react-frames": "^1.0.0-next.24072301",
-        "@arwes/react-text": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
-        "arwes": "^1.0.0-next.24072301",
+        "@arwes/react-animated": "^1.0.0-next.24072501",
+        "@arwes/react-animator": "^1.0.0-next.24072501",
+        "@arwes/react-bgs": "^1.0.0-next.24072501",
+        "@arwes/react-bleeps": "^1.0.0-next.24072501",
+        "@arwes/react-core": "^1.0.0-next.24072501",
+        "@arwes/react-frames": "^1.0.0-next.24072501",
+        "@arwes/react-text": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
+        "arwes": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20071,13 +20071,13 @@
     },
     "packages/react-animated": {
       "name": "@arwes/react-animated",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animator": "^1.0.0-next.24072301",
-        "@arwes/react-animator": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/animator": "^1.0.0-next.24072501",
+        "@arwes/react-animator": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20090,12 +20090,12 @@
     },
     "packages/react-animator": {
       "name": "@arwes/react-animator",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animator": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/animator": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20107,15 +20107,15 @@
     },
     "packages/react-bgs": {
       "name": "@arwes/react-bgs",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animated": "^1.0.0-next.24072301",
-        "@arwes/animator": "^1.0.0-next.24072301",
-        "@arwes/bgs": "^1.0.0-next.24072301",
-        "@arwes/react-animator": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/animated": "^1.0.0-next.24072501",
+        "@arwes/animator": "^1.0.0-next.24072501",
+        "@arwes/bgs": "^1.0.0-next.24072501",
+        "@arwes/react-animator": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20128,11 +20128,11 @@
     },
     "packages/react-bleeps": {
       "name": "@arwes/react-bleeps",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/bleeps": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
+        "@arwes/bleeps": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20144,14 +20144,14 @@
     },
     "packages/react-core": {
       "name": "@arwes/react-core",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animator": "^1.0.0-next.24072301",
-        "@arwes/bleeps": "^1.0.0-next.24072301",
-        "@arwes/react-animator": "^1.0.0-next.24072301",
-        "@arwes/react-bleeps": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
+        "@arwes/animator": "^1.0.0-next.24072501",
+        "@arwes/bleeps": "^1.0.0-next.24072501",
+        "@arwes/react-animator": "^1.0.0-next.24072501",
+        "@arwes/react-bleeps": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20164,12 +20164,12 @@
     },
     "packages/react-frames": {
       "name": "@arwes/react-frames",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/frames": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/frames": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20182,14 +20182,14 @@
     },
     "packages/react-text": {
       "name": "@arwes/react-text",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animator": "^1.0.0-next.24072301",
-        "@arwes/react-animator": "^1.0.0-next.24072301",
-        "@arwes/react-tools": "^1.0.0-next.24072301",
-        "@arwes/text": "^1.0.0-next.24072301",
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/animator": "^1.0.0-next.24072501",
+        "@arwes/react-animator": "^1.0.0-next.24072501",
+        "@arwes/react-tools": "^1.0.0-next.24072501",
+        "@arwes/text": "^1.0.0-next.24072501",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20201,7 +20201,7 @@
     },
     "packages/react-tools": {
       "name": "@arwes/react-tools",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
         "tslib": "2"
@@ -20215,18 +20215,18 @@
     },
     "packages/standalone": {
       "name": "arwes",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animated": "^1.0.0-next.24072301",
-        "@arwes/animator": "^1.0.0-next.24072301",
-        "@arwes/bgs": "^1.0.0-next.24072301",
-        "@arwes/bleeps": "^1.0.0-next.24072301",
-        "@arwes/frames": "^1.0.0-next.24072301",
-        "@arwes/styles": "^1.0.0-next.24072301",
-        "@arwes/text": "^1.0.0-next.24072301",
-        "@arwes/theme": "^1.0.0-next.24072301",
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/animated": "^1.0.0-next.24072501",
+        "@arwes/animator": "^1.0.0-next.24072501",
+        "@arwes/bgs": "^1.0.0-next.24072501",
+        "@arwes/bleeps": "^1.0.0-next.24072501",
+        "@arwes/frames": "^1.0.0-next.24072501",
+        "@arwes/styles": "^1.0.0-next.24072501",
+        "@arwes/text": "^1.0.0-next.24072501",
+        "@arwes/theme": "^1.0.0-next.24072501",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20235,7 +20235,7 @@
     },
     "packages/styles": {
       "name": "@arwes/styles",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
         "tslib": "2"
@@ -20246,11 +20246,11 @@
     },
     "packages/text": {
       "name": "@arwes/text",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/animated": "^1.0.0-next.24072301",
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/animated": "^1.0.0-next.24072501",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "tslib": "2"
       },
       "funding": {
@@ -20262,10 +20262,10 @@
     },
     "packages/theme": {
       "name": "@arwes/theme",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
-        "@arwes/tools": "^1.0.0-next.24072301",
+        "@arwes/tools": "^1.0.0-next.24072501",
         "csstype": "3",
         "tslib": "2"
       },
@@ -20275,7 +20275,7 @@
     },
     "packages/tools": {
       "name": "@arwes/tools",
-      "version": "1.0.0-next.24072301",
+      "version": "1.0.0-next.24072501",
       "license": "MIT",
       "dependencies": {
         "tslib": "2"

--- a/packages/animated/package.json
+++ b/packages/animated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/animated",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/animated/src/easing/easing.ts
+++ b/packages/animated/src/easing/easing.ts
@@ -131,7 +131,8 @@ const easing = {
   }
 }
 
-type Easing = EasingFn | keyof typeof easing
+type EasingName = keyof typeof easing
+type Easing = EasingFn | EasingName
 
-export type { Easing, EasingFn }
+export type { Easing, EasingName, EasingFn }
 export { easing }

--- a/packages/animator/package.json
+++ b/packages/animator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/animator",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
   "module": "./build/esm/index.js",
   "main": "./build/cjs/index.js",
   "dependencies": {
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/bgs/package.json
+++ b/packages/bgs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/bgs",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -43,8 +43,8 @@
     "motion": "10"
   },
   "dependencies": {
-    "@arwes/animated": "^1.0.0-next.24072301",
-    "@arwes/animator": "^1.0.0-next.24072301",
+    "@arwes/animated": "^1.0.0-next.24072501",
+    "@arwes/animator": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/bleeps/package.json
+++ b/packages/bleeps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/bleeps",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/frames/package.json
+++ b/packages/frames/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/frames",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
   "module": "./build/esm/index.js",
   "main": "./build/cjs/index.js",
   "dependencies": {
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "csstype": "3",
     "tslib": "2"
   },

--- a/packages/frames/src/createFrameSVGCorners/createFrameSVGCorners.ts
+++ b/packages/frames/src/createFrameSVGCorners/createFrameSVGCorners.ts
@@ -19,13 +19,13 @@ const defaultProps: Required<CreateFrameSVGCornersProps> = {
   padding: 0
 }
 
-const createFrameSVGCorners = (props: CreateFrameSVGCornersProps): FrameSVGSettings => {
+const createFrameSVGCorners = (props?: CreateFrameSVGCornersProps): FrameSVGSettings => {
   const {
     styled,
     strokeWidth: cw,
     cornerLength: cl,
     padding: p
-  } = { ...defaultProps, ...filterProps(props) }
+  } = { ...defaultProps, ...(props ? filterProps(props) : null) }
 
   const co = cw / 2
 

--- a/packages/frames/src/createFrameSVGKranox/createFrameSVGKranox.ts
+++ b/packages/frames/src/createFrameSVGKranox/createFrameSVGKranox.ts
@@ -31,7 +31,7 @@ type Point = [number | string, number | string]
 const toPath = (points: Point[]): FrameSVGSettingsPathDefinition =>
   points.map((p, i) => [i === 0 ? 'M' : 'L', ...p])
 
-const createFrameSVGKranox = (props: CreateFrameSVGKranoxProps): FrameSVGSettings => {
+const createFrameSVGKranox = (props?: CreateFrameSVGKranoxProps): FrameSVGSettings => {
   const {
     styled,
     padding: p,
@@ -40,7 +40,7 @@ const createFrameSVGKranox = (props: CreateFrameSVGKranoxProps): FrameSVGSetting
     squareSize: ss,
     smallLineLength: sll,
     largeLineLength: lll
-  } = { ...defaultProps, ...filterProps(props) }
+  } = { ...defaultProps, ...(props ? filterProps(props) : null) }
 
   const so = sw / 2 // Stroke offset.
   const bso = bsw / 2 // Background stroke offset.

--- a/packages/frames/src/createFrameSVGLines/createFrameSVGLines.ts
+++ b/packages/frames/src/createFrameSVGLines/createFrameSVGLines.ts
@@ -22,14 +22,14 @@ const defaultProps: Required<CreateFrameSVGLinesProps> = {
   smallLineLength: 16
 }
 
-const createFrameSVGLines = (props: CreateFrameSVGLinesProps): FrameSVGSettings => {
+const createFrameSVGLines = (props?: CreateFrameSVGLinesProps): FrameSVGSettings => {
   const {
     styled,
     padding: p,
     largeLineWidth: llw,
     smallLineWidth: slw,
     smallLineLength: sll
-  } = { ...defaultProps, ...filterProps(props) }
+  } = { ...defaultProps, ...(props ? filterProps(props) : null) }
 
   const polylineStyle: FrameSVGSettingsStyle = {
     strokeLinecap: 'square',

--- a/packages/frames/src/createFrameSVGNefrex/createFrameSVGNefrex.ts
+++ b/packages/frames/src/createFrameSVGNefrex/createFrameSVGNefrex.ts
@@ -29,7 +29,7 @@ type Point = [number | string, number | string]
 const toPath = (points: Point[]): FrameSVGSettingsPathDefinition =>
   points.map((p, i) => [i === 0 ? 'M' : 'L', ...p])
 
-const createFrameSVGNefrex = (props: CreateFrameSVGNefrexProps): FrameSVGSettings => {
+const createFrameSVGNefrex = (props?: CreateFrameSVGNefrexProps): FrameSVGSettings => {
   const {
     styled,
     squareSize: ss,
@@ -37,7 +37,7 @@ const createFrameSVGNefrex = (props: CreateFrameSVGNefrexProps): FrameSVGSetting
     smallLineLength: sll,
     largeLineLength: lll,
     padding: p
-  } = { ...defaultProps, ...filterProps(props) }
+  } = { ...defaultProps, ...(props ? filterProps(props) : null) }
 
   const so = strokeWidth / 2 // Stroke offset.
 

--- a/packages/frames/src/createFrameSVGOctagon/createFrameSVGOctagon.ts
+++ b/packages/frames/src/createFrameSVGOctagon/createFrameSVGOctagon.ts
@@ -33,7 +33,7 @@ type Point = [number | string, number | string]
 const toPath = (points: Point[]): FrameSVGSettingsPathDefinition =>
   points.map((p, i) => [i === 0 ? 'M' : 'L', ...p])
 
-const createFrameSVGOctagon = (props: CreateFrameSVGOctagonProps): FrameSVGSettings => {
+const createFrameSVGOctagon = (props?: CreateFrameSVGOctagonProps): FrameSVGSettings => {
   const {
     styled,
     leftTop,
@@ -43,7 +43,7 @@ const createFrameSVGOctagon = (props: CreateFrameSVGOctagonProps): FrameSVGSetti
     squareSize: ss,
     strokeWidth,
     padding: p
-  } = { ...defaultProps, ...filterProps(props) }
+  } = { ...defaultProps, ...(props ? filterProps(props) : null) }
 
   const so = strokeWidth / 2
 

--- a/packages/frames/src/createFrameSVGUnderline/createFrameSVGUnderline.ts
+++ b/packages/frames/src/createFrameSVGUnderline/createFrameSVGUnderline.ts
@@ -15,13 +15,13 @@ const defaultProps: Required<CreateFrameSVGUnderlineProps> = {
   padding: 0
 }
 
-const createFrameSVGUnderline = (props: CreateFrameSVGUnderlineProps): FrameSVGSettings => {
+const createFrameSVGUnderline = (props?: CreateFrameSVGUnderlineProps): FrameSVGSettings => {
   const {
     styled,
     squareSize: ss,
     strokeWidth: sw,
     padding: p
-  } = { ...defaultProps, ...filterProps(props) }
+  } = { ...defaultProps, ...(props ? filterProps(props) : null) }
 
   const so = sw / 2
 

--- a/packages/react-animated/package.json
+++ b/packages/react-animated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-animated",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -44,10 +44,10 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/animator": "^1.0.0-next.24072301",
-    "@arwes/react-animator": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/animator": "^1.0.0-next.24072501",
+    "@arwes/react-animator": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/react-animated/src/Animated/Animated.basic.sandbox.tsx
+++ b/packages/react-animated/src/Animated/Animated.basic.sandbox.tsx
@@ -15,7 +15,7 @@ const Item = (): ReactElement => {
             // - duration: number
             // - repeat: number
             // - delay: number | motion/stagger(value: number)
-            // - easing: 'linear' | (x: number) => number
+            // - easing: [name] | (x: number) => number
             // - direction: 'normal' | 'reverse' | 'alternate' | 'alternate-reverse'
             entering: { x: [0, 100], background: '#ff0' },
             exiting: { x: [100, 0], background: '#0ff' }

--- a/packages/react-animated/src/Animated/Animated.ts
+++ b/packages/react-animated/src/Animated/Animated.ts
@@ -15,7 +15,7 @@ import { mergeRefs } from '@arwes/react-tools'
 import { type AnimatorNode } from '@arwes/animator'
 import { useAnimator } from '@arwes/react-animator'
 
-import type { AnimatedSettings, AnimatedProp } from '../types.js'
+import type { AnimatedProp } from '../types.js'
 import { formatAnimatedCSSPropsShorthands } from '../internal/formatAnimatedCSSPropsShorthands/index.js'
 import { useAnimated } from '../useAnimated/index.js'
 
@@ -64,7 +64,9 @@ const Animated = <
   })
 
   const animatedSettingsListReceived = Array.isArray(animated) ? animated : [animated]
-  const animatedSettingsList = animatedSettingsListReceived.filter(Boolean) as AnimatedSettings[]
+  const animatedSettingsList = animatedSettingsListReceived
+    .map((item) => (typeof item === 'string' || Array.isArray(item) ? undefined : item))
+    .filter(Boolean)
 
   let initialAttributes: object | undefined
   if (animator) {

--- a/packages/react-animated/src/transitions/transitions.ts
+++ b/packages/react-animated/src/transitions/transitions.ts
@@ -1,32 +1,36 @@
 import { animate } from 'motion'
-import type { AnimatedSettings } from '../types.js'
-import { easing } from '@arwes/animated'
+import type { AnimationOptionsWithOverrides } from '@motionone/dom'
+import type { AnimatedSettings, AnimatedTransition } from '../types.js'
+import { type EasingName, easing } from '@arwes/animated'
 
 const transition = (
   prop: string,
   from: number | string,
   to: number | string,
-  back?: number | string
+  back?: number | string,
+  easing?: AnimationOptionsWithOverrides['easing'] | EasingName
 ): AnimatedSettings => ({
   transitions: {
-    entering: { [prop]: [from, to] },
-    exiting: { [prop]: [to, back ?? from] }
+    entering: { [prop]: [from, to], easing } as unknown as AnimatedTransition,
+    exiting: { [prop]: [to, back ?? from], easing } as unknown as AnimatedTransition
   }
 })
 
-const fade = (): AnimatedSettings => ({
+const fadeTransition = Object.freeze({
   transitions: {
     entering: { opacity: [0, 1] },
     exiting: { opacity: [1, 0] }
   }
 })
+const fade = (): AnimatedSettings => fadeTransition
 
-const flicker = (): AnimatedSettings => ({
+const flickerTransition = Object.freeze({
   transitions: {
     entering: { opacity: [0, 1, 0.5, 1], easing: easing.outSine },
     exiting: { opacity: [1, 0, 0.5, 0], easing: easing.outSine }
   }
 })
+const flicker = (): AnimatedSettings => flickerTransition
 
 const draw = (
   durationCustom?: number | undefined,
@@ -34,7 +38,7 @@ const draw = (
 ): AnimatedSettings => ({
   transitions: {
     entering: ({ element, duration }) => {
-      if (!(element instanceof SVGPathElement)) {
+      if (!(element instanceof SVGPathElement) || duration <= 0) {
         return
       }
 
@@ -50,7 +54,7 @@ const draw = (
       )
     },
     exiting: ({ element, duration }) => {
-      if (!(element instanceof SVGPathElement)) {
+      if (!(element instanceof SVGPathElement) || duration <= 0) {
         return
       }
 

--- a/packages/react-animated/src/types.ts
+++ b/packages/react-animated/src/types.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties, HTMLProps, SVGProps } from 'react'
 import type { MotionKeyframesDefinition, AnimationOptionsWithOverrides } from '@motionone/dom'
+import type { Easing } from '@arwes/animated'
 import type { AnimatorState, AnimatorDuration } from '@arwes/animator'
 
 // Animated
@@ -27,7 +28,7 @@ export type AnimatedCSSProps = Omit<CSSProperties, keyof AnimatedCSSPropsShortha
 export type AnimatedTransitionDefinition = MotionKeyframesDefinition & {
   duration?: number
   delay?: AnimationOptionsWithOverrides['delay']
-  easing?: AnimationOptionsWithOverrides['easing']
+  easing?: AnimationOptionsWithOverrides['easing'] | Easing
   repeat?: AnimationOptionsWithOverrides['repeat']
   direction?: AnimationOptionsWithOverrides['direction']
   options?: AnimationOptionsWithOverrides
@@ -72,9 +73,7 @@ export type AnimatedTransitionFunction =
   | ((config: AnimatedTransitionFunctionConfig) => AnimatedTransitionFunctionReturn)
   | ((config: AnimatedTransitionFunctionConfig) => void)
 
-export type AnimatedTransitionTypes = AnimatedTransitionFunction | AnimatedTransitionDefinition
-
-export type AnimatedTransition = AnimatedTransitionTypes | AnimatedTransitionTypes[]
+export type AnimatedTransition = AnimatedTransitionFunction | AnimatedTransitionDefinition
 
 export interface AnimatedSettings {
   initialAttributes?: HTMLProps<HTMLDivElement> | SVGProps<SVGPathElement>
@@ -84,7 +83,20 @@ export interface AnimatedSettings {
   }
 }
 
-export type AnimatedProp = AnimatedSettings | Array<AnimatedSettings | undefined> | undefined
+type AnimatedPropPreset = 'fade' | 'flicker' | 'draw'
+
+type AnimatedPropTransition = [
+  string,
+  number | string,
+  number | string,
+  (number | string)?,
+  (AnimationOptionsWithOverrides['easing'] | Easing)?
+]
+
+export type AnimatedProp =
+  | AnimatedSettings
+  | Array<AnimatedPropPreset | AnimatedPropTransition | AnimatedSettings | undefined>
+  | undefined
 
 // AnimatedX
 
@@ -97,8 +109,7 @@ export type AnimatedXTransitionFunctionReturn = AnimatedTransitionFunctionReturn
 export type AnimatedXTransitionFunction =
   | ((config: AnimatedXTransitionFunctionConfig) => AnimatedXTransitionFunctionReturn)
   | ((config: AnimatedXTransitionFunctionConfig) => void)
-export type AnimatedXTransitionTypes = AnimatedXTransitionDefinition | AnimatedXTransitionFunction
-export type AnimatedXTransition = AnimatedXTransitionTypes | AnimatedXTransitionTypes[]
+export type AnimatedXTransition = AnimatedXTransitionDefinition | AnimatedXTransitionFunction
 
 export interface AnimatedXSettings<States extends string> {
   initialAttributes?: HTMLProps<HTMLDivElement> | SVGProps<SVGPathElement>

--- a/packages/react-animator/package.json
+++ b/packages/react-animator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-animator",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -43,9 +43,9 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/animator": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/animator": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/react-bgs/package.json
+++ b/packages/react-bgs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-bgs",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -44,12 +44,12 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/animated": "^1.0.0-next.24072301",
-    "@arwes/animator": "^1.0.0-next.24072301",
-    "@arwes/bgs": "^1.0.0-next.24072301",
-    "@arwes/react-animator": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/animated": "^1.0.0-next.24072501",
+    "@arwes/animator": "^1.0.0-next.24072501",
+    "@arwes/bgs": "^1.0.0-next.24072501",
+    "@arwes/react-animator": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/react-bgs/src/internal/styles.ts
+++ b/packages/react-bgs/src/internal/styles.ts
@@ -7,8 +7,6 @@ export const positionedStyle: CSSProperties = {
   border: 0,
   margin: 0,
   padding: 0,
-  // In certain browsers, when a canvas has sizes with decimals above the 0.5,
-  // the browser clips the values to the edge. Round down the size so it doesn't happen.
-  width: 'round(down, 100%, 1px)',
-  height: 'round(down, 100%, 1px)'
+  width: '100%',
+  height: '100%'
 }

--- a/packages/react-bleeps/package.json
+++ b/packages/react-bleeps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-bleeps",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -43,8 +43,8 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/bleeps": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
+    "@arwes/bleeps": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-core",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -44,11 +44,11 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/animator": "^1.0.0-next.24072301",
-    "@arwes/bleeps": "^1.0.0-next.24072301",
-    "@arwes/react-animator": "^1.0.0-next.24072301",
-    "@arwes/react-bleeps": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
+    "@arwes/animator": "^1.0.0-next.24072501",
+    "@arwes/bleeps": "^1.0.0-next.24072501",
+    "@arwes/react-animator": "^1.0.0-next.24072501",
+    "@arwes/react-bleeps": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/react-frames/package.json
+++ b/packages/react-frames/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-frames",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -44,9 +44,9 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/frames": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/frames": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/react-frames/src/FrameSVG/FrameSVG.tsx
+++ b/packages/react-frames/src/FrameSVG/FrameSVG.tsx
@@ -23,10 +23,8 @@ const positionedStyle: CSSProperties = {
   border: 0,
   margin: 0,
   padding: 0,
-  // In certain browsers, when a SVG has sizes with decimals above the 0.5,
-  // the browser clips the values to the edge. Round down the size so it doesn't happen.
-  width: 'round(down, 100%, 1px)',
-  height: 'round(down, 100%, 1px)'
+  width: '100%',
+  height: '100%'
 }
 
 const FrameSVG = memo((props: FrameSVGProps): ReactElement => {

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-text",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -43,11 +43,11 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/animator": "^1.0.0-next.24072301",
-    "@arwes/react-animator": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
-    "@arwes/text": "^1.0.0-next.24072301",
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/animator": "^1.0.0-next.24072501",
+    "@arwes/react-animator": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
+    "@arwes/text": "^1.0.0-next.24072501",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/react-tools/package.json
+++ b/packages/react-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react-tools",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/react",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -43,15 +43,15 @@
     "react": "18"
   },
   "dependencies": {
-    "@arwes/react-animated": "^1.0.0-next.24072301",
-    "@arwes/react-animator": "^1.0.0-next.24072301",
-    "@arwes/react-bgs": "^1.0.0-next.24072301",
-    "@arwes/react-bleeps": "^1.0.0-next.24072301",
-    "@arwes/react-core": "^1.0.0-next.24072301",
-    "@arwes/react-frames": "^1.0.0-next.24072301",
-    "@arwes/react-text": "^1.0.0-next.24072301",
-    "@arwes/react-tools": "^1.0.0-next.24072301",
-    "arwes": "^1.0.0-next.24072301",
+    "@arwes/react-animated": "^1.0.0-next.24072501",
+    "@arwes/react-animator": "^1.0.0-next.24072501",
+    "@arwes/react-bgs": "^1.0.0-next.24072501",
+    "@arwes/react-bleeps": "^1.0.0-next.24072501",
+    "@arwes/react-core": "^1.0.0-next.24072501",
+    "@arwes/react-frames": "^1.0.0-next.24072501",
+    "@arwes/react-text": "^1.0.0-next.24072501",
+    "@arwes/react-tools": "^1.0.0-next.24072501",
+    "arwes": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arwes",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -40,15 +40,15 @@
   "module": "./build/esm/index.js",
   "main": "./build/cjs/index.js",
   "dependencies": {
-    "@arwes/animated": "^1.0.0-next.24072301",
-    "@arwes/animator": "^1.0.0-next.24072301",
-    "@arwes/bgs": "^1.0.0-next.24072301",
-    "@arwes/bleeps": "^1.0.0-next.24072301",
-    "@arwes/frames": "^1.0.0-next.24072301",
-    "@arwes/styles": "^1.0.0-next.24072301",
-    "@arwes/text": "^1.0.0-next.24072301",
-    "@arwes/theme": "^1.0.0-next.24072301",
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/animated": "^1.0.0-next.24072501",
+    "@arwes/animator": "^1.0.0-next.24072501",
+    "@arwes/bgs": "^1.0.0-next.24072501",
+    "@arwes/bleeps": "^1.0.0-next.24072501",
+    "@arwes/frames": "^1.0.0-next.24072501",
+    "@arwes/styles": "^1.0.0-next.24072501",
+    "@arwes/text": "^1.0.0-next.24072501",
+    "@arwes/theme": "^1.0.0-next.24072501",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/styles",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/text",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -43,8 +43,8 @@
     "motion": "10"
   },
   "dependencies": {
-    "@arwes/animated": "^1.0.0-next.24072301",
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/animated": "^1.0.0-next.24072501",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "tslib": "2"
   },
   "scripts": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/theme",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
   "module": "./build/esm/index.js",
   "main": "./build/cjs/index.js",
   "dependencies": {
-    "@arwes/tools": "^1.0.0-next.24072301",
+    "@arwes/tools": "^1.0.0-next.24072501",
     "csstype": "3",
     "tslib": "2"
   },

--- a/packages/theme/src/createThemeBreakpoints/createThemeBreakpoints.test.ts
+++ b/packages/theme/src/createThemeBreakpoints/createThemeBreakpoints.test.ts
@@ -2,41 +2,63 @@ import { describe, test, expect } from 'vitest'
 
 import { createThemeBreakpoints } from './createThemeBreakpoints'
 
+test('Should create breakpoints property with breakpoint keys', () => {
+  const bps = createThemeBreakpoints([
+    { key: 'a', value: 'x' },
+    { key: 'b', value: 'y' },
+    { key: 'c', value: 'z' }
+  ])
+  expect(bps.breakpoints).toStrictEqual(['a', 'b', 'c'])
+})
+
+test('Should create settings property with provided settings', () => {
+  const bps = createThemeBreakpoints([
+    { key: 'a', value: 'x' },
+    { key: 'b', value: 'y' },
+    { key: 'c', value: 'z' }
+  ])
+  expect(bps.settings).toStrictEqual([
+    { key: 'a', value: 'x' },
+    { key: 'b', value: 'y' },
+    { key: 'c', value: 'z' }
+  ])
+})
+
 describe('up', () => {
   test('Should return media query min-width', () => {
-    const bgs = createThemeBreakpoints()
-    expect(bgs.up('100px')).toBe('@media (min-width: 100px)')
+    const bps = createThemeBreakpoints()
+    expect(bps.up('100px')).toBe('@media (min-width: 100px)')
   })
 
   test('Should return media query without the strip', () => {
-    const bgs = createThemeBreakpoints()
-    expect(bgs.up('100px', { strip: true })).toBe('(min-width: 100px)')
+    const bps = createThemeBreakpoints()
+    expect(bps.up('100px', { strip: true })).toBe('(min-width: 100px)')
   })
 })
 
 describe('down', () => {
   test('Should return media query max-width', () => {
-    const bgs = createThemeBreakpoints()
-    expect(bgs.down('20rem')).toBe('@media (max-width: calc(20rem - 1px))')
+    const bps = createThemeBreakpoints()
+    expect(bps.down('20rem')).toBe('@media (max-width: calc(20rem - 1px))')
   })
 
   test('Should return media query without the strip', () => {
-    const bgs = createThemeBreakpoints()
-    expect(bgs.down('20rem', { strip: true })).toBe('(max-width: calc(20rem - 1px))')
+    const bps = createThemeBreakpoints()
+    expect(bps.down('20rem', { strip: true })).toBe('(max-width: calc(20rem - 1px))')
   })
 })
 
 describe('between', () => {
   test('Should return media of a range', () => {
-    const bgs = createThemeBreakpoints()
-    expect(bgs.between('100px', '200px')).toBe(
+    const bps = createThemeBreakpoints()
+    expect(bps.between('100px', '200px')).toBe(
       '@media (min-width: 100px) and (max-width: calc(200px - 1px))'
     )
   })
 
   test('Should return media query without the strip', () => {
-    const bgs = createThemeBreakpoints()
-    expect(bgs.between('100px', '200px', { strip: true })).toBe(
+    const bps = createThemeBreakpoints()
+    expect(bps.between('100px', '200px', { strip: true })).toBe(
       '(min-width: 100px) and (max-width: calc(200px - 1px))'
     )
   })

--- a/packages/theme/src/createThemeBreakpoints/createThemeBreakpoints.ts
+++ b/packages/theme/src/createThemeBreakpoints/createThemeBreakpoints.ts
@@ -1,8 +1,18 @@
-import type { ThemeSettingsBreakpoints, ThemeBreakpoints } from '../types.js'
+import type {
+  ThemeSettingsBreakpointsKeyListItem,
+  ThemeSettingsBreakpoints,
+  ThemeBreakpoints
+} from '../types.js'
 
 const createThemeBreakpoints = <Keys extends string | number = string | number>(
   settings: ThemeSettingsBreakpoints<Keys> = []
 ): ThemeBreakpoints<Keys> => {
+  const breakpoints = (
+    settings.filter((item) => typeof item !== 'string') as unknown as Array<
+      ThemeSettingsBreakpointsKeyListItem<Keys>
+    >
+  ).map((item) => item.key)
+
   const getBreakpointValue = (key: string | number): string => {
     if (typeof key === 'string') {
       for (const item of settings) {
@@ -35,6 +45,7 @@ const createThemeBreakpoints = <Keys extends string | number = string | number>(
   }
 
   return Object.freeze({
+    breakpoints,
     settings,
     up,
     down,

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -41,6 +41,7 @@ export type ThemeStyleValue = CSSProperties
 export type ThemeStyle = (index: number) => ThemeStyleValue
 
 export interface ThemeBreakpoints<Keys extends string | number = string | number> {
+  breakpoints: Keys[]
   settings: ThemeSettingsBreakpoints<Keys>
   up: (key: Keys, opts?: { strip?: boolean }) => string
   down: (key: Keys, opts?: { strip?: boolean }) => string

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arwes/tools",
-  "version": "1.0.0-next.24072301",
+  "version": "1.0.0-next.24072501",
   "publishConfig": {
     "access": "public"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "removeComments": true,
     "resolveJsonModule": false
   },
   "exclude": [


### PR DESCRIPTION
## `@arwes/theme`

- Add theme breakpoints `breakpoints: Keys` property.

## `@arwes/react-animated`

- Fix animated object definition to remove unrequired array state transitions.
- Add animated preset names with `'fade'`, `'flicker'`, and `'draw'`.
- Add animated transition shortcut as array.

## `@arwes/react-bgs`

- Fix background default CSS styles to support iOS.

## `@arwes/react-frames`

- Fix `<FrameSVG>` default CSS styles to support iOS.